### PR TITLE
Implement method to provide `function-name` variable within a function scope

### DIFF
--- a/lisp/emacs-lisp/byte-run.el
+++ b/lisp/emacs-lisp/byte-run.el
@@ -252,6 +252,8 @@ The return value is undefined.
 	       (cons 'prog1 (cons def declarations))
 	     def))))))
 
+(defvar function-name nil "Variable defined within the scope of `defun' storing the name of the function")
+
 ;; Now that we defined defmacro we can use it!
 (defmacro defun (name arglist &optional docstring &rest body)
   "Define NAME as a function.
@@ -263,7 +265,7 @@ interpreted according to `defun-declarations-alist'.
 The return value is undefined.
 
 \(fn NAME ARGLIST &optional DOCSTRING DECL &rest BODY)"
-  ;; DNM(Krey): How the hug do i define this only within the macro >.<
+  ;; NOTICE(Krey): Used to define `function-name'
   (let ((function-name name))
     ;; We can't just have `decl' as an &optional argument, because we need
     ;; to distinguish

--- a/lisp/emacs-lisp/byte-run.el
+++ b/lisp/emacs-lisp/byte-run.el
@@ -264,56 +264,56 @@ The return value is undefined.
 
 \(fn NAME ARGLIST &optional DOCSTRING DECL &rest BODY)"
   ;; DNM(Krey): How the hug do i define this only within the macro >.<
-  (setq function-name name)
-  ;; We can't just have `decl' as an &optional argument, because we need
-  ;; to distinguish
-  ;;    (defun foo (arg) (toto) nil)
-  ;; from
-  ;;    (defun foo (arg) (toto)).
-  (declare (doc-string 3) (indent 2))
-  (or name (error "Cannot define '%s' as a function" name))
-  (if (null
-       (and (listp arglist)
-            (null (delq t (mapcar #'symbolp arglist)))))
-      (error "Malformed arglist: %s" arglist))
-  (let ((decls (cond
-                ((eq (car-safe docstring) 'declare)
-                 (prog1 (cdr docstring) (setq docstring nil)))
-                ((and (stringp docstring)
-		      (eq (car-safe (car body)) 'declare))
-                 (prog1 (cdr (car body)) (setq body (cdr body)))))))
-    (if docstring (setq body (cons docstring body))
-      (if (null body) (setq body '(nil))))
-    (let ((declarations
-           (mapcar
-            #'(lambda (x)
-                (let ((f (cdr (assq (car x) defun-declarations-alist))))
-                  (cond
-                   (f (apply (car f) name arglist (cdr x)))
-                   ;; Yuck!!
-                   ((and (featurep 'cl)
-                         (memq (car x)  ;C.f. cl-do-proclaim.
-                               '(special inline notinline optimize warn)))
-                    (push (list 'declare x)
-                          (if (stringp docstring)
-                              (if (eq (car-safe (cadr body)) 'interactive)
-                                  (cddr body)
-                                (cdr body))
-                            (if (eq (car-safe (car body)) 'interactive)
-                                (cdr body)
-                              body)))
-                    nil)
-                   (t (message "Warning: Unknown defun property `%S' in %S"
-                               (car x) name)))))
-                   decls))
-          (def (list 'defalias
-                     (list 'quote name)
-                     (list 'function
-                           (cons 'lambda
-                                 (cons arglist body))))))
-      (if declarations
-          (cons 'prog1 (cons def declarations))
-          def))))
+  (let (function-name name)
+    ;; We can't just have `decl' as an &optional argument, because we need
+    ;; to distinguish
+    ;;    (defun foo (arg) (toto) nil)
+    ;; from
+    ;;    (defun foo (arg) (toto)).
+    (declare (doc-string 3) (indent 2))
+    (or name (error "Cannot define '%s' as a function" name))
+    (if (null
+         (and (listp arglist)
+              (null (delq t (mapcar #'symbolp arglist)))))
+        (error "Malformed arglist: %s" arglist))
+    (let ((decls (cond
+                  ((eq (car-safe docstring) 'declare)
+                   (prog1 (cdr docstring) (setq docstring nil)))
+                  ((and (stringp docstring)
+                        (eq (car-safe (car body)) 'declare))
+                   (prog1 (cdr (car body)) (setq body (cdr body)))))))
+      (if docstring (setq body (cons docstring body))
+        (if (null body) (setq body '(nil))))
+      (let ((declarations
+             (mapcar
+              #'(lambda (x)
+                  (let ((f (cdr (assq (car x) defun-declarations-alist))))
+                    (cond
+                     (f (apply (car f) name arglist (cdr x)))
+                     ;; Yuck!!
+                     ((and (featurep 'cl)
+                           (memq (car x)  ;C.f. cl-do-proclaim.
+                                 '(special inline notinline optimize warn)))
+                      (push (list 'declare x)
+                            (if (stringp docstring)
+                                (if (eq (car-safe (cadr body)) 'interactive)
+                                    (cddr body)
+                                  (cdr body))
+                              (if (eq (car-safe (car body)) 'interactive)
+                                  (cdr body)
+                                body)))
+                      nil)
+                     (t (message "Warning: Unknown defun property `%S' in %S"
+                                 (car x) name)))))
+              decls))
+            (def (list 'defalias
+                       (list 'quote name)
+                       (list 'function
+                             (cons 'lambda
+                                   (cons arglist body))))))
+        (if declarations
+            (cons 'prog1 (cons def declarations))
+          def)))))
 
 
 ;; Redefined in byte-opt.el.

--- a/lisp/emacs-lisp/byte-run.el
+++ b/lisp/emacs-lisp/byte-run.el
@@ -252,8 +252,6 @@ The return value is undefined.
 	       (cons 'prog1 (cons def declarations))
 	     def))))))
 
-(defvar function-name nil "Variable defined within the scope of `defun' storing the name of the function")
-
 ;; Now that we defined defmacro we can use it!
 (defmacro defun (name arglist &optional docstring &rest body)
   "Define NAME as a function.
@@ -262,9 +260,11 @@ See also the function `interactive'.
 DECL is a declaration, optional, of the form (declare DECLS...) where
 DECLS is a list of elements of the form (PROP . VALUES).  These are
 interpreted according to `defun-declarations-alist'.
+Variable 'function-name' can be used to reference a function name within the scope of this macro.
 The return value is undefined.
 
-\(fn NAME ARGLIST &optional DOCSTRING DECL &rest BODY)"
+\(fn NAME ARGLIST &optional DOCSTRING DECL &rest BODY)
+"
   ;; NOTICE(Krey): Used to define `function-name'
   (let ((function-name name))
     ;; We can't just have `decl' as an &optional argument, because we need

--- a/lisp/emacs-lisp/byte-run.el
+++ b/lisp/emacs-lisp/byte-run.el
@@ -264,7 +264,7 @@ The return value is undefined.
 
 \(fn NAME ARGLIST &optional DOCSTRING DECL &rest BODY)"
   ;; DNM(Krey): How the hug do i define this only within the macro >.<
-  (let (function-name name)
+  (let ((function-name name))
     ;; We can't just have `decl' as an &optional argument, because we need
     ;; to distinguish
     ;;    (defun foo (arg) (toto) nil)

--- a/lisp/emacs-lisp/byte-run.el
+++ b/lisp/emacs-lisp/byte-run.el
@@ -263,6 +263,8 @@ interpreted according to `defun-declarations-alist'.
 The return value is undefined.
 
 \(fn NAME ARGLIST &optional DOCSTRING DECL &rest BODY)"
+  ;; DNM(Krey): How the hug do i define this only within the macro >.<
+  (setq function-name name)
   ;; We can't just have `decl' as an &optional argument, because we need
   ;; to distinguish
   ;;    (defun foo (arg) (toto) nil)


### PR DESCRIPTION
This implements a variable 'function-name' available within a scope of macro 'defun' so that it can be referenced i.e

```elisp
(defun something () ((princ "Called from '%1$s'! function-name)))
```

Fixes: https://github.com/Kreymacs/Kreymacs/issues/17

Signed-off-by: Jacob Hrbek <kreyren@rixotstudio.cz>